### PR TITLE
Makefile auto-documentável

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,58 @@
-container=app
+ifeq ($(container),)
+	# Se a variavel container não foi setada
+	# use 'app' como padrão
+	container=app
+endif
+$(info Make: VAR container="$(container)".)
 
-up:
+# Por padrão make sem nada vai rodar 'help'
+.DEFAULT_GOAL := help
+
+# PHONY especifica que 'help' é um comando, não uma target que precisa ser
+# compilada.
+.PHONY: help
+
+# Roubado de: https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+# grep -E faz o matchig: [COMANDO]:[espaço]<COMENTÁRIO>[espaço].
+#      Nota: Em makefiles $ tem que ser trocado por $$
+#
+# sort: ordena os resultados alfabeticamente.
+#
+# awk: formata o retorno do sort em "[COMANDO]<30 espaços>[COMENTÁRIO]
+#      usando ":.?##" como field separator (FS).
+help:
+	@echo "$$(tput bold)Comandos:$$(tput sgr0)";echo;
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "%-30s%s\n", $$1, $$2}'
+
+up: ## Sobe os containers no modo detached (-d)
 	docker-compose up -d
 
-up-debug:
+up-debug: ## Sobe os containers em modo de debug (sem -d)
 	docker-compose up
 
-build:
+clean: ## Remove volumes associados ao container
 	docker-compose rm -vsf
 	docker-compose down -v --remove-orphans
-	docker-compose build
-	docker-compose up -d
 
-down:
+build: ## Rebuilda os containers
+	$(MAKE) clean
+	docker-compose build
+	$(MAKE) up
+
+down: ## Para e remove os containers
 	docker-compose down
 
-run:
+run: ## Comentário
 	docker-compose run {container} /bin/bash
 
-jumpin:
+jumpin: ## Comentário
 	docker-compose run {container} bash
 
-test:
+test: ## Comentário
 	docker-compose run {container} pytest ./tests/
 
-test-file:
+test-file: ## Comentário
 	docker-compose run {container} pytest ./tests/ --group $(FILE)
 
-tail-logs:
+tail-logs: ## Comentário
 	docker-compose logs -f {container}


### PR DESCRIPTION
Fiz umas modificações no Makefile, mas não terminei por que não sei bem como ele é usado, deixei uns valores padrões só pra mostrar se vocês quiserem usar e modificar.

```bash
$ make
Make: VAR container="app".
Comandos:

build                         Rebuilda os containers
clean                         Remove volumes associados ao container
down                          Para e remove os containers
jumpin                        Comentário
run                           Comentário
tail-logs                     Comentário
test                          Comentário
test-file                     Comentário
up-debug                      Sobe os containers em modo de debug (sem -d)
up                            Sobe os containers no modo detached (-d)
```

Outras coisas que podem ser adicionadas depois:
```
ifeq ($(container),)
	# Se a variavel container não foi setada
	# use 'app' como padrão
	container=app
endif
```
coloquei esse teste pra saber se a variável foi setada, mas outra alternativa é criar um arquivo `.env` e usar um [include](https://www.gnu.org/software/make/manual/html_node/Include.html).
```
include .env
export
```
